### PR TITLE
feat: add getUser helper and hook usage

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -5,7 +5,7 @@ import { isUnauthorizedError } from "../lib/authUtils";
 export function useAuth() {
   const { data: user, isLoading, error } = useQuery({
     queryKey: ["/api/auth/user"],
-    queryFn: () => api.get("/api/auth/user"),
+    queryFn: api.getUser,
     retry: (failureCount, error) => {
       // Don't retry on 401 errors to prevent loops
       if (isUnauthorizedError(error as Error)) {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -99,6 +99,9 @@ class ApiClient {
 const apiClient = new ApiClient();
 
 export const api = {
+  // Auth
+  getUser: () => apiClient.get("/api/auth/user"),
+
   // Products
   getProducts: () => apiClient.get("/api/products"),
   getProduct: (id: string) => apiClient.get(`/api/products/${id}`),


### PR DESCRIPTION
## Summary
- add getUser helper to API client
- use getUser in useAuth hook

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68b4692f4db88325aafbb3a4dbf5e006