### PR TITLE
Create HTTP server and simplify JSON logging

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 
 import 'dotenv/config';
 import express, { type Request, Response, NextFunction } from 'express';
+import { createServer } from 'http';
 import { registerRoutes } from './routes';
 import { setupVite, serveStatic, log } from './vite';
 
@@ -16,10 +17,9 @@ app.use((req, res, next) => {
   let capturedJsonResponse: Record<string, any> | undefined;
 
   const originalResJson = res.json.bind(res);
-  // @ts-expect-error: mantener firma flexible
-  res.json = function (body: any, ...args: any[]) {
+  res.json = function (body: any) {
     capturedJsonResponse = body;
-    return originalResJson(body, ...args);
+    return originalResJson(body);
   };
 
   res.on('finish', () => {
@@ -40,8 +40,8 @@ app.use((req, res, next) => {
 });
 
 (async () => {
-  // Registra rutas (puede devolver un http.Server)
-  const server = await registerRoutes(app);
+  await registerRoutes(app);
+  const server = createServer(app);
 
   // Manejo de errores global
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {


### PR DESCRIPTION
## Summary
- remove spread arguments and ts-expect-error from custom res.json logger
- instantiate HTTP server after registering routes and reuse for Vite setup and listening

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68b469306b1c8325b2fe2fe265160ad8