### PR TITLE
fix: update db import in seed script

### DIFF
--- a/server/seed.ts
+++ b/server/seed.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import bcrypt from 'bcryptjs';
-import { db } from './db.ts_old';
+import { db } from './db';
 import { sql } from 'drizzle-orm';
 
 async function main() {


### PR DESCRIPTION
## Summary
- fix seed script to import db from current module path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: sh: 1: tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b46931f9208325946a6b84e6833273