### PR TITLE
fix: align Nest API module format with compiler output

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,6 @@
   "name": "@petshop/api",
   "version": "1.0.0",
   "private": true,
-  "type": "module",
   "scripts": {
     "build": "nest build",
     "start": "node dist/main.js",


### PR DESCRIPTION
## Summary
- remove the "type": "module" flag from the API package.json so Node treats the compiled NestJS output as CommonJS
- ensure the backend can start by keeping the runtime module format aligned with the Nest build artifacts

## Testing
- ⚠️ `pnpm install` *(fails: registry downloads are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e74d5c874c83259ff1acd65772b22f